### PR TITLE
Added support for monsters by name

### DIFF
--- a/Release/scripts/elementalML.ash
+++ b/Release/scripts/elementalML.ash
@@ -79,7 +79,6 @@ void main(string monsterOrML) {
 	}
 	float monster_natural_ML = to_float(monsterOrML);
 	monster chosen_monster = to_monster(monsterOrML);
-	print(chosen_monster);
 	if (monster_natural_ML == 0.0) {
 		if (chosen_monster.defense_element != $element[none]) {
 			print("You will take approximately " + rounder(damage(chosen_monster.raw_attack, chosen_monster.defense_element),-1) + " from " + chosen_monster + "'s initial elemental hit.", "black");

--- a/Release/scripts/elementalML.ash
+++ b/Release/scripts/elementalML.ash
@@ -70,18 +70,31 @@ float rounder(float number, int place) {
 	return value;
 }
 
-void main(float monster_natural_ML) {
-	if(!get_property("noEle").to_boolean() && user_confirm("Would you like to tell Aenimus that you're using this script? It would be nice to know, but feel free to say no.")) {
-		notify aenimus;
-		set_property("noEle", "true");
-	} else {
+void main(string monsterOrML) {
+	if(!get_property("noEle").to_boolean()) {
+		if (user_confirm("Would you like to tell Aenimus that you're using this script? It would be nice to know, but feel free to say no.")) {
+			notify aenimus;
+		}
 		set_property("noEle", "true");
 	}
-    print("You will take approximately " + rounder(damage(monster_natural_ML, hot),-1) + " from a hot monster's initial elemental hit.", "red");
-    print("You will take approximately " + rounder(damage(monster_natural_ML, cold),-1) + " from a cold monster's initial elemental hit.", "blue");
-    print("You will take approximately " + rounder(damage(monster_natural_ML, spooky),-1) + " from a spooky monster's initial elemental hit.", "gray");
-    print("You will take approximately " + rounder(damage(monster_natural_ML, stench),-1) + " from a stench monster's initial elemental hit.", "green");
-    print("You will take approximately " + rounder(damage(monster_natural_ML, sleaze),-1) + " from a sleaze monster's initial elemental hit.", "purple");	
+	float monster_natural_ML = to_float(monsterOrML);
+	monster chosen_monster = to_monster(monsterOrML);
+	print(chosen_monster);
+	if (monster_natural_ML == 0.0) {
+		if (chosen_monster.defense_element != $element[none]) {
+			print("You will take approximately " + rounder(damage(chosen_monster.raw_attack, chosen_monster.defense_element),-1) + " from " + chosen_monster + "'s initial elemental hit.", "black");
+		}
+		else {
+			print("Either that monster isn't elementally aligned, or we didn't understand what you said. Enter a monster name, or a base attack value.");
+		}
+	}
+	else {
+		print("You will take approximately " + rounder(damage(monster_natural_ML, hot),-1) + " from a hot monster's initial elemental hit.", "red");
+		print("You will take approximately " + rounder(damage(monster_natural_ML, cold),-1) + " from a cold monster's initial elemental hit.", "blue");
+		print("You will take approximately " + rounder(damage(monster_natural_ML, spooky),-1) + " from a spooky monster's initial elemental hit.", "gray");
+		print("You will take approximately " + rounder(damage(monster_natural_ML, stench),-1) + " from a stench monster's initial elemental hit.", "green");
+		print("You will take approximately " + rounder(damage(monster_natural_ML, sleaze),-1) + " from a sleaze monster's initial elemental hit.", "purple");	
+	}
 	print("Remember that the monster's natural ML is your mainstat for scalers.", "green");
 	print("You can now also simply type el in the CLI to run this script!.", "green");
 }


### PR DESCRIPTION
This cleans up some of the control flow, and allows you to instead of specifying ML, specify the name of the monster you are expecting to fight. If Mafia knows the monster, it will use the appropriate ML and element without intervention.